### PR TITLE
remove Map and Map polyfill

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,24 +22,25 @@ import ptBr from "./src/locale/pt-BR";
 import ruRu from "./src/locale/ru-RU";
 import zhCn from "./src/locale/zh-CN";
 
-var localeDefinitions = (new Map)
-    .set("ca-ES", caEs)
-    .set("de-DE", deDe)
-    .set("en-CA", enCa)
-    .set("en-GB", enGb)
-    .set("en-US", enUs)
-    .set("es-ES", esEs)
-    .set("fi-FI", fiFi)
-    .set("fr-CA", frCa)
-    .set("fr-FR", frFr)
-    .set("he-IL", heIl)
-    .set("it-IT", itIt)
-    .set("mk-MK", mkMk)
-    .set("nl-NL", nlNl)
-    .set("pl-PL", plPl)
-    .set("pt-BR", ptBr)
-    .set("ru-RU", ruRu)
-    .set("zh-CN", zhCn);
+var localeDefinitions = {
+    "ca-ES": caEs,
+    "de-DE": deDe,
+    "en-CA": enCa,
+    "en-GB": enGb,
+    "en-US": enUs,
+    "es-ES": esEs,
+    "fi-FI": fiFi,
+    "fr-CA": frCa,
+    "fr-FR": frFr,
+    "he-IL": heIl,
+    "it-IT": itIt,
+    "mk-MK": mkMk,
+    "nl-NL": nlNl,
+    "pl-PL": plPl,
+    "pt-BR": ptBr,
+    "ru-RU": ruRu,
+    "zh-CN": zhCn
+};
 
 var defaultLocale = locale(enUs);
 export var format = defaultLocale.format;
@@ -47,7 +48,7 @@ export var formatPrefix = defaultLocale.formatPrefix;
 
 export function localeFormat(definition) {
   if (typeof definition === "string") {
-    definition = localeDefinitions.get(definition);
+    definition = localeDefinitions[definition];
     if (!definition) return null;
   }
   return locale(definition);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/d3/d3-format.git"
   },
   "scripts": {
-    "pretest": "mkdir -p build && d3-bundler --polyfill-map --format=umd --name=format -- index.js > build/format.js",
+    "pretest": "mkdir -p build && d3-bundler --format=umd --name=format -- index.js > build/format.js",
     "test": "faucet `find test -name '*-test.js'`",
     "prepublish": "npm run test && uglifyjs build/format.js -c -m -o build/format.min.js && rm -f build/format.zip && zip -j build/format.zip -- LICENSE README.md build/format.js build/format.min.js"
   },


### PR DESCRIPTION
cc/ @mbostock 

Hi!

This PR removes Map and Map polyfill in favor of plain objects. All tests pass.  

We're relying on several of your modules, and we love that you're breaking up d3 into es6 modules, but we don't love having to include a polyfill.  Since you're using string lookups anyway, can we convince you to switch back to vanilla objects?

Thanks!
FormidableLabs