### PR TITLE
Replaced \x with \u sequence in JSON locale data

### DIFF
--- a/locale/ca-ES.json
+++ b/locale/ca-ES.json
@@ -2,5 +2,5 @@
   "decimal": ",",
   "thousands": ".",
   "grouping": [3],
-  "currency": ["", "\xa0€"]
+  "currency": ["", "\u00a0€"]
 }

--- a/locale/cs-CZ.json
+++ b/locale/cs-CZ.json
@@ -1,6 +1,6 @@
 {
   "decimal": ",",
-  "thousands": "\xa0",
+  "thousands": "\u00a0",
   "grouping": [3],
-  "currency": ["", "\xa0Kč"]
+  "currency": ["", "\u00a0Kč"]
 }

--- a/locale/de-CH.json
+++ b/locale/de-CH.json
@@ -2,5 +2,5 @@
   "decimal": ",",
   "thousands": "'",
   "grouping": [3],
-  "currency": ["", "\xa0CHF"]
+  "currency": ["", "\u00a0CHF"]
 }

--- a/locale/de-DE.json
+++ b/locale/de-DE.json
@@ -2,5 +2,5 @@
   "decimal": ",",
   "thousands": ".",
   "grouping": [3],
-  "currency": ["", "\xa0€"]
+  "currency": ["", "\u00a0€"]
 }

--- a/locale/es-ES.json
+++ b/locale/es-ES.json
@@ -2,5 +2,5 @@
   "decimal": ",",
   "thousands": ".",
   "grouping": [3],
-  "currency": ["", "\xa0€"]
+  "currency": ["", "\u00a0€"]
 }

--- a/locale/fi-FI.json
+++ b/locale/fi-FI.json
@@ -1,6 +1,6 @@
 {
   "decimal": ",",
-  "thousands": "\xa0",
+  "thousands": "\u00a0",
   "grouping": [3],
-  "currency": ["", "\xa0€"]
+  "currency": ["", "\u00a0€"]
 }

--- a/locale/fr-CA.json
+++ b/locale/fr-CA.json
@@ -1,6 +1,6 @@
 {
   "decimal": ",",
-  "thousands": "\xa0",
+  "thousands": "\u00a0",
   "grouping": [3],
   "currency": ["", "$"]
 }

--- a/locale/fr-FR.json
+++ b/locale/fr-FR.json
@@ -2,5 +2,5 @@
   "decimal": ",",
   "thousands": ".",
   "grouping": [3],
-  "currency": ["", "\xa0€"]
+  "currency": ["", "\u00a0€"]
 }

--- a/locale/hu-HU.json
+++ b/locale/hu-HU.json
@@ -1,6 +1,6 @@
 {
   "decimal": ",",
-  "thousands": "\xa0",
+  "thousands": "\u00a0",
   "grouping": [3],
-  "currency": ["", "\xa0Ft"]
+  "currency": ["", "\u00a0Ft"]
 }

--- a/locale/mk-MK.json
+++ b/locale/mk-MK.json
@@ -2,5 +2,5 @@
   "decimal": ",",
   "thousands": ".",
   "grouping": [3],
-  "currency": ["", "\xa0ден."]
+  "currency": ["", "\u00a0ден."]
 }

--- a/locale/nl-NL.json
+++ b/locale/nl-NL.json
@@ -2,5 +2,5 @@
   "decimal": ",",
   "thousands": ".",
   "grouping": [3],
-  "currency": ["€\xa0", ""]
+  "currency": ["€\u00a0", ""]
 }

--- a/locale/ru-RU.json
+++ b/locale/ru-RU.json
@@ -1,6 +1,6 @@
 {
   "decimal": ",",
-  "thousands": "\xa0",
+  "thousands": "\u00a0",
   "grouping": [3],
-  "currency": ["", "\xa0руб."]
+  "currency": ["", "\u00a0руб."]
 }

--- a/locale/sv-SE.json
+++ b/locale/sv-SE.json
@@ -1,6 +1,6 @@
 {
   "decimal": ",",
-  "thousands": "\xa0",
+  "thousands": "\u00a0",
   "grouping": [3],
   "currency": ["", "SEK"]
 }


### PR DESCRIPTION
With reference to #22, this pull request replaces the \x non breaking space with the \u equivalent.