### PR TITLE
Fixed calling sequence for defaultLocale

### DIFF
--- a/src/defaultLocale.js
+++ b/src/defaultLocale.js
@@ -4,6 +4,13 @@ var locale;
 export var format;
 export var formatPrefix;
 
+function defaultLocale(definition) {
+  locale = formatLocale(definition);
+  format = locale.format;
+  formatPrefix = locale.formatPrefix;
+  return locale;
+}
+
 defaultLocale({
   decimal: ".",
   thousands: ",",
@@ -11,9 +18,4 @@ defaultLocale({
   currency: ["$", ""]
 });
 
-export default function defaultLocale(definition) {
-  locale = formatLocale(definition);
-  format = locale.format;
-  formatPrefix = locale.formatPrefix;
-  return locale;
-}
+export default defaultLocale; 


### PR DESCRIPTION
Moved definition of defaultLocale function above calling of function to make sure function definition is available before it is being called. This was creating issues with tools which work directly on ES2015+ (rollup in my case), and consuming src files directly.