### PR TITLE
Allow percentage suffix customization per locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ Returns a *locale* object for the specified *definition* with [*locale*.format](
 * `grouping` - the array of group sizes (e.g., `[3]`), cycled as needed.
 * `currency` - the currency prefix and suffix (e.g., `["$", ""]`).
 * `numerals` - optional; an array of ten strings to replace the numerals 0-9.
+* `percent` - optional; the percent suffix (default to `"%"`).
 
 Note that the *thousands* property is a misnomer, as the grouping definition allows groups other than thousands.
 

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Returns a *locale* object for the specified *definition* with [*locale*.format](
 * `grouping` - the array of group sizes (e.g., `[3]`), cycled as needed.
 * `currency` - the currency prefix and suffix (e.g., `["$", ""]`).
 * `numerals` - optional; an array of ten strings to replace the numerals 0-9.
-* `percent` - optional; the percent suffix (default to `"%"`).
+* `percent` - optional; the percent suffix (defaults to `"%"`).
 
 Note that the *thousands* property is a misnomer, as the grouping definition allows groups other than thousands.
 

--- a/locale/fr-FR.json
+++ b/locale/fr-FR.json
@@ -3,5 +3,5 @@
   "thousands": ".",
   "grouping": [3],
   "currency": ["", "\u00a0€"],
-  "percentage": "\u202f%"
+  "percent": "\u202f%"
 }

--- a/locale/fr-FR.json
+++ b/locale/fr-FR.json
@@ -2,5 +2,6 @@
   "decimal": ",",
   "thousands": ".",
   "grouping": [3],
-  "currency": ["", "\u00a0€"]
+  "currency": ["", "\u00a0€"],
+  "percentage": "\u202f%"
 }

--- a/src/locale.js
+++ b/src/locale.js
@@ -13,7 +13,7 @@ export default function(locale) {
       currency = locale.currency,
       decimal = locale.decimal,
       numerals = locale.numerals ? formatNumerals(locale.numerals) : identity,
-      percentage = locale.percentage || "%";
+      percent = locale.percent || "%";
 
   function newFormat(specifier) {
     specifier = formatSpecifier(specifier);
@@ -31,7 +31,7 @@ export default function(locale) {
     // Compute the prefix and suffix.
     // For SI-prefix, the suffix is lazily computed.
     var prefix = symbol === "$" ? currency[0] : symbol === "#" && /[boxX]/.test(type) ? "0" + type.toLowerCase() : "",
-        suffix = symbol === "$" ? currency[1] : /[%p]/.test(type) ? percentage : "";
+        suffix = symbol === "$" ? currency[1] : /[%p]/.test(type) ? percent : "";
 
     // What format function should we use?
     // Is this an integer type?

--- a/src/locale.js
+++ b/src/locale.js
@@ -12,7 +12,8 @@ export default function(locale) {
   var group = locale.grouping && locale.thousands ? formatGroup(locale.grouping, locale.thousands) : identity,
       currency = locale.currency,
       decimal = locale.decimal,
-      numerals = locale.numerals ? formatNumerals(locale.numerals) : identity;
+      numerals = locale.numerals ? formatNumerals(locale.numerals) : identity,
+      percentage = locale.percentage || "%";
 
   function newFormat(specifier) {
     specifier = formatSpecifier(specifier);
@@ -30,7 +31,7 @@ export default function(locale) {
     // Compute the prefix and suffix.
     // For SI-prefix, the suffix is lazily computed.
     var prefix = symbol === "$" ? currency[0] : symbol === "#" && /[boxX]/.test(type) ? "0" + type.toLowerCase() : "",
-        suffix = symbol === "$" ? currency[1] : /[%p]/.test(type) ? "%" : "";
+        suffix = symbol === "$" ? currency[1] : /[%p]/.test(type) ? percentage : "";
 
     // What format function should we use?
     // Is this an integer type?

--- a/test/defaultLocale-test.js
+++ b/test/defaultLocale-test.js
@@ -12,13 +12,15 @@ var frFr = {
   "decimal": ",",
   "thousands": ".",
   "grouping": [3],
-  "currency": ["", "\u00a0€"]
+  "currency": ["", "\u00a0€"],
+  "percentage": "\u202f%"
 };
 
 tape("d3.formatDefaultLocale(definition) returns the new default locale", function(test) {
   var locale = d3.formatDefaultLocale(frFr);
   try {
     test.equal(locale.format("$,.2f")(12345678.90), "12.345.678,90 €");
+    test.equal(locale.format(",.0%")(12345678.90), "1.234.567.890 %");
     test.end();
   } finally {
     d3.formatDefaultLocale(enUs);

--- a/test/defaultLocale-test.js
+++ b/test/defaultLocale-test.js
@@ -13,14 +13,14 @@ var frFr = {
   "thousands": ".",
   "grouping": [3],
   "currency": ["", "\u00a0€"],
-  "percentage": "\u202f%"
+  "percent": "\u202f%"
 };
 
 tape("d3.formatDefaultLocale(definition) returns the new default locale", function(test) {
   var locale = d3.formatDefaultLocale(frFr);
   try {
     test.equal(locale.format("$,.2f")(12345678.90), "12.345.678,90 €");
-    test.equal(locale.format(",.0%")(12345678.90), "1.234.567.890 %");
+    test.equal(locale.format(",.0%")(12345678.90), "1.234.567.890\u202f%");
     test.end();
   } finally {
     d3.formatDefaultLocale(enUs);


### PR DESCRIPTION
Hello and thanks for making d3 :)

French locale rules precise that % symbol should be prepended by a fine unbreakable space (`\u202f`):
https://fr.wikipedia.org/wiki/Pourcentage#Notation
https://fr.wikipedia.org/wiki/Pour_cent#Typographie
https://fr.wikipedia.org/wiki/Pourcentage#cite_note-2 (source)

To do so, I suggest adding the ability to customize the percentage suffix per locale (I'm not aware of other locales that would require it, but I'm no expert!), defaulting to `%`.