### PR TITLE
In France, thousands separator is a no-break space

### DIFF
--- a/locale/fr-FR.json
+++ b/locale/fr-FR.json
@@ -1,6 +1,6 @@
 {
   "decimal": ",",
-  "thousands": ".",
+  "thousands": "\u00a0",
   "grouping": [3],
   "currency": ["", "\u00a0€"],
   "percent": "\u202f%"


### PR DESCRIPTION
This closes #50.

See for example numeraljs French settings: https://github.com/adamwdraper/Numeral-js/blob/master/locales/fr.js