### PR TITLE
Add syntax option to trim insignificant zeros

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ An alias for [*locale*.formatPrefix](#locale_formatPrefix) on the [default local
 Returns a new format function for the given string *specifier*. The returned function takes a number as the only argument, and returns a string representing the formatted number. The general form of a specifier is:
 
 ```
-[​[fill]align][sign][symbol][0][width][,][.precision][type]
+[​[fill]align][sign][symbol][0][width][,][.precision][type][t]
 ```
 
 The *fill* can be any character. The presence of a fill character is signaled by the *align* character following it, which must be one of the following:
@@ -160,6 +160,14 @@ d3.format(".2")(4.2); // "4.2"
 d3.format(".1")(42);  // "4e+1"
 d3.format(".1")(4.2); // "4"
 ```
+
+The `t` (trim) option removes insignificant trailing zeros across all format types. This is most commonly used in conjunction with types `r`, `e`, `s` and `%`. For example:
+```js
+d3.format("s")(1500);  // "1.50000k"
+d3.format("st")(1500); // "1.5k"
+```
+
+The default (none) format type is equivalent to `gt`.
 
 <a name="locale_formatPrefix" href="#locale_formatPrefix">#</a> <i>locale</i>.<b>formatPrefix</b>(<i>specifier</i>, <i>value</i>) [<>](https://github.com/d3/d3-format/blob/master/src/locale.js#L127 "Source")
 

--- a/src/formatDefault.js
+++ b/src/formatDefault.js
@@ -1,14 +1,5 @@
+import trim from "./trim";
+
 export default function(x, p) {
-  x = x.toPrecision(p);
-
-  out: for (var n = x.length, i = 1, i0 = -1, i1; i < n; ++i) {
-    switch (x[i]) {
-      case ".": i0 = i1 = i; break;
-      case "0": if (i0 === 0) i0 = i; i1 = i; break;
-      case "e": break out;
-      default: if (i0 > 0) i0 = 0; break;
-    }
-  }
-
-  return i0 > 0 ? x.slice(0, i0) + x.slice(i1 + 1) : x;
+  return trim(x.toPrecision(p));
 }

--- a/src/formatSpecifier.js
+++ b/src/formatSpecifier.js
@@ -1,7 +1,7 @@
 import formatTypes from "./formatTypes";
 
 // [[fill]align][sign][symbol][0][width][,][.precision][type]
-var re = /^(?:(.)?([<>=^]))?([+\-\( ])?([$#])?(0)?(\d+)?(,)?(\.\d+)?([a-z%])?$/i;
+var re = /^(?:(.)?([<>=^]))?([+\-\( ])?([$#])?(0)?(\d+)?(,)?(\.\d+)?([a-z%])?(t)?$/i;
 
 export default function formatSpecifier(specifier) {
   return new FormatSpecifier(specifier);
@@ -21,7 +21,8 @@ function FormatSpecifier(specifier) {
       width = match[6] && +match[6],
       comma = !!match[7],
       precision = match[8] && +match[8].slice(1),
-      type = match[9] || "";
+      type = match[9] || "",
+      trim = !!match[10];
 
   // The "n" type is an alias for ",g".
   if (type === "n") comma = true, type = "g";
@@ -41,6 +42,7 @@ function FormatSpecifier(specifier) {
   this.comma = comma;
   this.precision = precision;
   this.type = type;
+  this.trim = trim;
 }
 
 FormatSpecifier.prototype.toString = function() {
@@ -52,5 +54,6 @@ FormatSpecifier.prototype.toString = function() {
       + (this.width == null ? "" : Math.max(1, this.width | 0))
       + (this.comma ? "," : "")
       + (this.precision == null ? "" : "." + Math.max(0, this.precision | 0))
-      + this.type;
+      + this.type
+      + (this.trim ? "t" : "");
 };

--- a/src/locale.js
+++ b/src/locale.js
@@ -5,6 +5,7 @@ import formatSpecifier from "./formatSpecifier";
 import formatTypes from "./formatTypes";
 import {prefixExponent} from "./formatPrefixAuto";
 import identity from "./identity";
+import trimInsignificantZeros from "./trim";
 
 var prefixes = ["y","z","a","f","p","n","µ","m","","k","M","G","T","P","E","Z","Y"];
 
@@ -26,7 +27,8 @@ export default function(locale) {
         width = specifier.width,
         comma = specifier.comma,
         precision = specifier.precision,
-        type = specifier.type;
+        type = specifier.type,
+        trim = specifier.trim;
 
     // Compute the prefix and suffix.
     // For SI-prefix, the suffix is lazily computed.
@@ -61,6 +63,10 @@ export default function(locale) {
         // Perform the initial formatting.
         var valueNegative = value < 0;
         value = formatType(Math.abs(value), precision);
+
+        if (trim) {
+          value = trimInsignificantZeros(value);
+        }
 
         // If a negative value rounds to zero during formatting, treat as positive.
         if (valueNegative && +value === 0) valueNegative = false;

--- a/src/trim.js
+++ b/src/trim.js
@@ -1,0 +1,17 @@
+// trim insignificant zeros: "1.2000k" -> "1.2k"
+export default function(s) {
+  out: for (var n = s.length, i = 1, i0 = -1, i1; i < n; ++i) {
+    switch (s[i]) {
+      case ".": i0 = i1 = i; break;
+      case "0": if (i0 === 0) i0 = i; i1 = i; break;
+      default:
+        if (i0 > 0) {
+          if (isNaN(s[i])) break out;
+          i0 = 0;
+        }
+        break;
+    }
+  }
+
+  return i0 > 0 ? s.slice(0, i0) + s.slice(i1 + 1) : s;
+}

--- a/test/format-trim-test.js
+++ b/test/format-trim-test.js
@@ -1,0 +1,74 @@
+var tape = require("tape"),
+    format = require("../");
+
+tape("format(\"rt\") trims insignificant zeros", function(test) {
+  var f = format.format("rt");
+  test.equal(f(1), "1");
+  test.equal(f(0.1), "0.1");
+  test.equal(f(0.01), "0.01");
+  test.equal(f(10.0001), "10.0001");
+  test.equal(f(123.45), "123.45");
+  test.equal(f(123.456), "123.456");
+  test.equal(f(123.4567), "123.457");
+  test.equal(f(0.000009), "0.000009");
+  test.equal(f(0.0000009), "0.0000009");
+  test.equal(f(0.00000009), "0.00000009");
+  test.equal(f(0.111119), "0.111119");
+  test.equal(f(0.1111119), "0.111112");
+  test.equal(f(0.11111119), "0.111111");
+  test.end();
+});
+
+tape("format(\"et\") trims insignificant zeros", function(test) {
+  var f = format.format("et");
+  test.equal(f(0), "0e+0");
+  test.equal(f(42), "4.2e+1");
+  test.equal(f(42000000), "4.2e+7");
+  test.equal(f(0.042), "4.2e-2");
+  test.equal(f(-4), "-4e+0");
+  test.equal(f(-42), "-4.2e+1");
+  test.end();
+});
+
+tape("format(\"st\") trims insignificant zeros", function(test) {
+  var f = format.format("st");
+  test.equal(f(0), "0");
+  test.equal(f(1), "1");
+  test.equal(f(10), "10");
+  test.equal(f(100), "100");
+  test.equal(f(999.5), "999.5");
+  test.equal(f(999500), "999.5k");
+  test.equal(f(1000), "1k");
+  test.equal(f(1400), "1.4k");
+  test.equal(f(1500), "1.5k");
+  test.equal(f(1500.5), "1.5005k");
+  test.equal(f(1e-15), "1f");
+  test.equal(f(1e-12), "1p");
+  test.equal(f(1e-9), "1n");
+  test.equal(f(1e-6), "1µ");
+  test.equal(f(1e-3), "1m");
+  test.equal(f(1e0), "1");
+  test.equal(f(1e3), "1k");
+  test.equal(f(1e6), "1M");
+  test.equal(f(1e9), "1G");
+  test.equal(f(1e12), "1T");
+  test.equal(f(1e15), "1P");
+  test.end();
+});
+
+tape("format(\"%t\") trims insignificant zeros", function(test) {
+  var f = format.format("%t");
+  test.equal(f(0), "0%");
+  test.equal(f(0.1), "10%");
+  test.equal(f(0.01), "1%");
+  test.equal(f(0.001), "0.1%");
+  test.equal(f(0.0001), "0.01%");
+  test.end();
+});
+
+tape("trimming respects commas", function(test) {
+  var f = format.format(",gt");
+  test.equal(f(10000.0), "10,000");
+  test.equal(f(10000.1), "10,000.1");
+  test.end();
+});

--- a/test/formatSpecifier-test.js
+++ b/test/formatSpecifier-test.js
@@ -25,6 +25,7 @@ tape("formatSpecifier(\"\") has the expected defaults", function(test) {
   test.equal(s.comma, false);
   test.equal(s.precision, undefined);
   test.equal(s.type, "");
+  test.equal(s.trim, false);
   test.end();
 });
 
@@ -61,6 +62,8 @@ tape("formatSpecifier(specifier).toString() reflects current field values", func
   test.equal((s.precision = 2, s) + "", "_^+$012,.2");
   test.equal((s.type = "f", s) + "", "_^+$012,.2f");
   test.equal(format.format(s)(42), "+$0,000,042.00");
+  test.equal((s.trim = true, s) + "", "_^+$012,.2ft");
+  test.equal(format.format(s)(42), "+$0,000,000,042");
   test.end();
 });
 


### PR DESCRIPTION
This PR solves #54.

It introduces a new option (`t`) in the specifier syntax that enables trimming of insignificant zeros across all format types.

Example:
```
d3.format("s")(1500);  // "1.50000k"
d3.format("st")(1500); // "1.5k"
```

Also added test cases and a paragraph in the docs.

Fully backwards compatible with the current syntax. The default format type (none) behavior remains the same and is equivalent to the new `gt` format.