### PR TITLE
Update sv-SE.json

### DIFF
--- a/locale/sv-SE.json
+++ b/locale/sv-SE.json
@@ -2,5 +2,5 @@
   "decimal": ",",
   "thousands": "\u00a0",
   "grouping": [3],
-  "currency": ["", "SEK"]
+  "currency": ["", " kr"]
 }


### PR DESCRIPTION
We write `4 566,00 kr` (sv punct, sv spacing, sv locale) for `SEK 4,566.00` (en). Not `SEK4566,00` and not `kr4566` and not `4566kr`. We accept `4566.00 kr` (en punct, en spacing, en locale) when writing things internationally and the context is clear; otherwise `4566.00 SEK` is common if the (currency) context is unclear. In accounting, negative balances are red and with a negative sign and without currency specifier (contextual), like so: `4566` or `-4566` (imagine that text being red).