### PR TITLE
allow minus sign to be configured in locale

### DIFF
--- a/src/defaultLocale.js
+++ b/src/defaultLocale.js
@@ -9,7 +9,7 @@ defaultLocale({
   thousands: ",",
   grouping: [3],
   currency: ["$", ""],
-  minusSign: "-"
+  minus: "-"
 });
 
 export default function defaultLocale(definition) {

--- a/src/defaultLocale.js
+++ b/src/defaultLocale.js
@@ -8,7 +8,8 @@ defaultLocale({
   decimal: ".",
   thousands: ",",
   grouping: [3],
-  currency: ["$", ""]
+  currency: ["$", ""],
+  minusSign: "-"
 });
 
 export default function defaultLocale(definition) {

--- a/src/locale.js
+++ b/src/locale.js
@@ -15,7 +15,7 @@ export default function(locale) {
       decimal = locale.decimal,
       numerals = locale.numerals ? formatNumerals(locale.numerals) : identity,
       percent = locale.percent || "%",
-      minus = locale.minus || "-"
+      minus = locale.minus || "-";
 
   function newFormat(specifier) {
     specifier = formatSpecifier(specifier);

--- a/src/locale.js
+++ b/src/locale.js
@@ -15,7 +15,7 @@ export default function(locale) {
       decimal = locale.decimal,
       numerals = locale.numerals ? formatNumerals(locale.numerals) : identity,
       percent = locale.percent || "%",
-      minusSign = locale.minusSign || "-"
+      minus = locale.minus || "-"
 
   function newFormat(specifier) {
     specifier = formatSpecifier(specifier);
@@ -81,7 +81,7 @@ export default function(locale) {
         if (valueNegative && +value === 0) valueNegative = false;
 
         // Compute the prefix and suffix.
-        valuePrefix = (valueNegative ? (sign === "(" ? sign : minusSign) : sign === "-" || sign === "(" ? "" : sign) + valuePrefix;
+        valuePrefix = (valueNegative ? (sign === "(" ? sign : minus) : sign === "-" || sign === "(" ? "" : sign) + valuePrefix;
         
         valueSuffix = (type === "s" ? prefixes[8 + prefixExponent / 3] : "") + valueSuffix + (valueNegative && sign === "(" ? ")" : "");
 

--- a/src/locale.js
+++ b/src/locale.js
@@ -14,7 +14,8 @@ export default function(locale) {
       currency = locale.currency,
       decimal = locale.decimal,
       numerals = locale.numerals ? formatNumerals(locale.numerals) : identity,
-      percent = locale.percent || "%";
+      percent = locale.percent || "%",
+      minusSign = locale.minusSign || "-"
 
   function newFormat(specifier) {
     specifier = formatSpecifier(specifier);
@@ -80,7 +81,8 @@ export default function(locale) {
         if (valueNegative && +value === 0) valueNegative = false;
 
         // Compute the prefix and suffix.
-        valuePrefix = (valueNegative ? (sign === "(" ? sign : "-") : sign === "-" || sign === "(" ? "" : sign) + valuePrefix;
+        valuePrefix = (valueNegative ? (sign === "(" ? sign : minusSign) : sign === "-" || sign === "(" ? "" : sign) + valuePrefix;
+        
         valueSuffix = (type === "s" ? prefixes[8 + prefixExponent / 3] : "") + valueSuffix + (valueNegative && sign === "(" ? ")" : "");
 
         // Break the formatted value into the integer “value” part that can be


### PR DESCRIPTION
This adds a new property to the locale: `minusSign`.
Using this property the character used as the prefix for negative numbers can be specified in the locale. The default is defined as the current character minus-hyphen `U+002D`.

This implements the idea in the issue https://github.com/d3/d3-format/issues/62 that it should be possible to override the character used in the locale.

All the tests pass, although I haven't added a new case to check if the new `minusSign` locale prop gets used everywhere as it should. Please advise if you want me to do something else/more here.