### PR TITLE
add scale format "* number"

### DIFF
--- a/src/formatSpecifier.js
+++ b/src/formatSpecifier.js
@@ -1,5 +1,5 @@
 // [[fill]align][sign][symbol][0][width][,][.precision][~][type]
-var re = /^(?:(.)?([<>=^]))?([+\-( ])?([$#])?(0)?(\d+)?(,)?(\.\d+)?(~)?([a-z%])?$/i;
+var re = /^(?:(.)?([<>=^]))?([+\-( ])?([$#])?(0)?(\d+)?(,)?(\.\d+)?(~)?([a-z%])?(\*(\d+(\.\d*)?))?$/i;
 
 export default function formatSpecifier(specifier) {
   if (!(match = re.exec(specifier))) throw new Error("invalid format: " + specifier);
@@ -14,7 +14,8 @@ export default function formatSpecifier(specifier) {
     comma: match[7],
     precision: match[8] && match[8].slice(1),
     trim: match[9],
-    type: match[10]
+    type: match[10],
+    scale: parseFloat(match[12]) || 1
   });
 }
 
@@ -31,6 +32,7 @@ export function FormatSpecifier(specifier) {
   this.precision = specifier.precision === undefined ? undefined : +specifier.precision;
   this.trim = !!specifier.trim;
   this.type = specifier.type === undefined ? "" : specifier.type + "";
+  this.scale = specifier.scale;
 }
 
 FormatSpecifier.prototype.toString = function() {
@@ -43,5 +45,6 @@ FormatSpecifier.prototype.toString = function() {
       + (this.comma ? "," : "")
       + (this.precision === undefined ? "" : "." + Math.max(0, this.precision | 0))
       + (this.trim ? "~" : "")
-      + this.type;
+      + this.type
+      + "*" + this.scale;
 };

--- a/src/locale.js
+++ b/src/locale.js
@@ -32,7 +32,8 @@ export default function(locale) {
         comma = specifier.comma,
         precision = specifier.precision,
         trim = specifier.trim,
-        type = specifier.type;
+        type = specifier.type,
+        scale = specifier.scale;
 
     // The "n" type is an alias for ",g".
     if (type === "n") comma = true, type = "g";
@@ -66,6 +67,8 @@ export default function(locale) {
       var valuePrefix = prefix,
           valueSuffix = suffix,
           i, n, c;
+
+      value *= scale;
 
       if (type === "c") {
         valueSuffix = formatType(value) + valueSuffix;

--- a/test/format-type-scale-test.js
+++ b/test/format-type-scale-test.js
@@ -1,0 +1,10 @@
+var tape = require("tape"),
+  format = require("../");
+
+tape("format(\"*scale\") scales the value correctly", function (test) {
+  var f = format.format(".0f*10000");
+  test.equal(f(0), "0");
+  test.equal(f(0.0384), "384");
+  test.equal(f(-0.0384), "-384");
+  test.end();
+});


### PR DESCRIPTION
The main reason for adding this format specifier is to format numbers as basis points (bps). The syntax is: * number.