### PR TITLE
A types for typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "unpkg": "dist/d3-format.min.js",
   "jsdelivr": "dist/d3-format.min.js",
   "module": "src/index.js",
+  "types": "src/types.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/d3/d3-format.git"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "unpkg": "dist/d3-format.min.js",
   "jsdelivr": "dist/d3-format.min.js",
   "module": "src/index.js",
-  "types": "src/types.d.ts",
+  "types": "src/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/d3/d3-format.git"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'd3-format' {
+declare namespace d3 {
     function formatDefaultLocale(definition: LocaleDefinition): LocaleFormatter
     function format(specifier: string): (value: number) => string
     function formatPrefix(specifier: string, value: number): string
@@ -10,8 +10,8 @@ declare module 'd3-format' {
     function precisionFixed(step: number): number
     function precisionPrefix(step: number, value: number): number
     function precisionRound(step: number, max: number): number
-
-    class FormatSpecifier {
+    
+    export class FormatSpecifier {
         constructor(specifier: FormatSpecifier)
 
         fill?: string
@@ -26,7 +26,7 @@ declare module 'd3-format' {
         type?: string
     }
 
-    interface LocaleDefinition {
+    export interface LocaleDefinition {
         decimal?: string
         thousands?: string
         grouping?: number[]
@@ -37,8 +37,10 @@ declare module 'd3-format' {
         nan?: string
     }
 
-    interface LocaleFormatter {
+    export interface LocaleFormatter {
         format(specifier: string): (value: number) => string
         formatPrefix(specifier: string, value: number): string
     }
 }
+
+export = d3

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,44 @@
+declare module 'd3-format' {
+    function formatDefaultLocale(definition: LocaleDefinition): LocaleFormatter
+    function format(specifier: string): (value: number) => string
+    function formatPrefix(specifier: string, value: number): string
+
+    function formatLocale(definition: LocaleDefinition): LocaleFormatter
+    
+    function formatSpecifier(specifier: string): FormatSpecifier
+
+    function precisionFixed(step: number): number
+    function precisionPrefix(step: number, value: number): number
+    function precisionRound(step: number, max: number): number
+
+    class FormatSpecifier {
+        constructor(specifier: FormatSpecifier)
+
+        fill?: string
+        align?: string
+        sign?: string
+        symbol?: string
+        zero?: boolean
+        width?: number
+        comma?: boolean
+        precision?: number
+        trim?: boolean
+        type?: string
+    }
+
+    interface LocaleDefinition {
+        decimal?: string
+        thousands?: string
+        grouping?: number[]
+        currency?: string[]
+        numerals?: string[]
+        percent?: string
+        minus?: string
+        nan?: string
+    }
+
+    interface LocaleFormatter {
+        format(specifier: string): (value: number) => string
+        formatPrefix(specifier: string, value: number): string
+    }
+}


### PR DESCRIPTION
A simple file to improve typescript usage of d3-format.

Use the following import in a typescript file.
`import * as d3 from 'd3-format'`