### PR TITLE
Use Russian Ruble sign in ru-RU locale

### DIFF
--- a/locale/ru-RU.json
+++ b/locale/ru-RU.json
@@ -2,5 +2,5 @@
   "decimal": ",",
   "thousands": "\u00a0",
   "grouping": [3],
-  "currency": ["", "\u00a0руб."]
+  "currency": ["", "\u00a0\u20bd"]
 }


### PR DESCRIPTION
For discussion.

There's a [unicode symbol for Russian Ruble](https://www.fileformat.info/info/unicode/char/20bd/index.htm) (`\u20bd`) that's widely used. It's been around for some time and I'm asked very often to display it instead of `руб.`, even by people in finance, not dataviz/design people. Might be good to add this here.