### PR TITLE
Fix package.json "main" to point to build es5 - Jest error on import modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "locale/*.json"
   ],
   "module": "src/index.js",
-  "main": "src/index.js",
+  "main": "dist/d3-format.js",
   "jsdelivr": "dist/d3-format.min.js",
   "unpkg": "dist/d3-format.min.js",
   "exports": {


### PR DESCRIPTION
Fix package.json "main" to point to build es5 - Jest error on import modules