### PR TITLE
add locale file for zh-TW

### DIFF
--- a/locale/zh-TW.json
+++ b/locale/zh-TW.json
@@ -1,0 +1,6 @@
+{
+  "decimal": ".",
+  "thousands": ",",
+  "grouping": [3],
+  "currency": ["NT$", ""]
+}


### PR DESCRIPTION
This is in reference to the issue https://github.com/d3/d3-format/issues/130

Added a locale file for zh-TW.

References: 
https://en.wikipedia.org/wiki/Decimal_separator#Digit_grouping
https://en.wikipedia.org/wiki/New_Taiwan_dollar