### PR TITLE
Fix for issue 134

### DIFF
--- a/src/locale.js
+++ b/src/locale.js
@@ -20,7 +20,7 @@ export default function(locale) {
       minus = locale.minus === undefined ? "−" : locale.minus + "",
       nan = locale.nan === undefined ? "NaN" : locale.nan + "";
 
-  function newFormat(specifier) {
+  function newFormat(specifier, fixedUnitParam="") {
     specifier = formatSpecifier(specifier);
 
     var fill = specifier.fill,
@@ -32,7 +32,8 @@ export default function(locale) {
         comma = specifier.comma,
         precision = specifier.precision,
         trim = specifier.trim,
-        type = specifier.type;
+        type = specifier.type,
+        fixedUnit = fixedUnitParam;
 
     // The "n" type is an alias for ",g".
     if (type === "n") comma = true, type = "g";
@@ -87,7 +88,8 @@ export default function(locale) {
 
         // Compute the prefix and suffix.
         valuePrefix = (valueNegative ? (sign === "(" ? sign : minus) : sign === "-" || sign === "(" ? "" : sign) + valuePrefix;
-        valueSuffix = (type === "s" ? prefixes[8 + prefixExponent / 3] : "") + valueSuffix + (valueNegative && sign === "(" ? ")" : "");
+        var units = fixedUnit === "" ? (type === "s" ? prefixes[8 + prefixExponent / 3] : "") : fixedUnit;
+        valueSuffix = units + valueSuffix + (valueNegative && sign === "(" ? ")" : "");
 
         // Break the formatted value into the integer “value” part that can be
         // grouped, and fractional or exponential “suffix” part that is not.
@@ -132,12 +134,12 @@ export default function(locale) {
   }
 
   function formatPrefix(specifier, value) {
-    var f = newFormat((specifier = formatSpecifier(specifier), specifier.type = "f", specifier)),
-        e = Math.max(-8, Math.min(8, Math.floor(exponent(value) / 3))) * 3,
+    var e = Math.max(-8, Math.min(8, Math.floor(exponent(value) / 3))) * 3,
         k = Math.pow(10, -e),
-        prefix = prefixes[8 + e / 3];
+        prefix = prefixes[8 + e / 3],
+        f = newFormat((specifier = formatSpecifier(specifier), specifier.type = "f", specifier), prefix);
     return function(value) {
-      return f(k * value) + prefix;
+      return f(k * value);
     };
   }
 

--- a/test/formatPrefix-test.js
+++ b/test/formatPrefix-test.js
@@ -1,22 +1,40 @@
 import assert from "assert";
-import {formatPrefix} from "../src/index.js";
+import {format, formatPrefix} from "../src/index.js";
 
-it("formatPrefix(\"s\", value)(number) formats with the SI prefix appropriate to the specified value", () => {
+it("formatPrefix(\",.0s\", value)(number) formats with the SI prefix appropriate to the specified value", () => {
   assert.strictEqual(formatPrefix(",.0s", 1e-6)(.00042), "420µ");
   assert.strictEqual(formatPrefix(",.0s", 1e-6)(.0042), "4,200µ");
+});
+
+it("formatPrefix(\",.3s\", value)(number) formats with the SI prefix appropriate to the specified value", () => {
   assert.strictEqual(formatPrefix(",.3s", 1e-3)(.00042), "0.420m");
 });
 
-it("formatPrefix(\"s\", value)(number) uses yocto for very small reference values", () => {
+it("formatPrefix(\",.0s\", value)(number) uses yocto for very small reference values", () => {
   assert.strictEqual(formatPrefix(",.0s", 1e-27)(1e-24), "1y");
 });
 
-it("formatPrefix(\"s\", value)(number) uses yotta for very small reference values", () => {
+it("formatPrefix(\",.0s\", value)(number) uses yotta for very small reference values", () => {
   assert.strictEqual(formatPrefix(",.0s", 1e27)(1e24), "1Y");
 });
 
-it("formatPrefix(\"$,s\", value)(number) formats with the specified SI prefix", () => {
+it("formatPrefix(\" $12,.1s\", value)(number) formats with the specified SI prefix", () => {
+  // The fixed length of 12 is inclusive of the unit 'M'
   const f = formatPrefix(" $12,.1s", 1e6);
-  assert.strictEqual(f(-42e6),  "      −$42.0M");
-  assert.strictEqual(f(+4.2e6), "        $4.2M");
+  assert.strictEqual(f(-42e6),  "     −$42.0M");
+  assert.strictEqual(f(+4.2e6), "       $4.2M");
+})
+
+it("formatPrefix(\" $12,.1s\", value)(number) matches format(\" $12,.2s\")(number) when the units are the same", () => {
+  // The fixed length of 12 is inclusive of the unit 'M'
+  const fp = formatPrefix(" $12,.1s", 1e6);
+  const f = format(" $12,.2s");
+  assert.strictEqual(fp(+4.2e6), "       $4.2M");
+  assert.strictEqual(f(+4.2e6),  "       $4.2M");
+})
+
+it("formatPrefix(\"($~s\", value)(number) formats with the SI prefix inside parentheses", () => {
+  assert.strictEqual(formatPrefix("($~s", 1e3)(1e3), "$1k");
+  assert.strictEqual(formatPrefix("($~s", 1e3)(-1e3), "($1k)");
 });
+


### PR DESCRIPTION
This fixed the issue filed in https://github.com/d3/d3-format/issues/134

This changes the behaviour from:

```
>formatPrefix("(~s", 1e3)(-1e3)`
(1)k
```
To be:
```
>formatPrefix("(~s", 1e3)(-1e3)`
(1k) 
```

A side effect of this change is we now include the unit to be included in the padding length, e.g:
```
>formatPrefix("(~s", 1e3)(-1e3)`
      −$42.0M
```
Becomes:
```
>formatPrefix("(~s", 1e3)(-1e3)`
     −$42.0M
```
